### PR TITLE
[PLAT-1815] Add a Cop to enforce passing a block to File.open

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,27 @@
 PATH
   remote: .
   specs:
-    rubocop-notarize (0.1.1)
+    rubocop-notarize (0.1.3)
       rubocop (>= 0.92)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.1)
+    ast (2.4.2)
     coderay (1.1.3)
     diff-lcs (1.3)
+    json (2.6.2)
     method_source (1.0.0)
-    parallel (1.19.2)
-    parser (2.7.2.0)
+    parallel (1.22.1)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (12.3.3)
-    regexp_parser (1.8.1)
-    rexml (3.2.4)
+    regexp_parser (2.5.0)
+    rexml (3.2.5)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -34,19 +35,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.92.0)
+    rubocop (1.31.2)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 2.7.1.5)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
-      rexml
-      rubocop-ast (>= 0.5.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.18.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.7.1)
-      parser (>= 2.7.1.5)
-    ruby-progressbar (1.10.1)
-    unicode-display_width (1.7.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.19.1)
+      parser (>= 3.1.1.0)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.2.0)
 
 PLATFORMS
   ruby

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,6 +3,11 @@ Performance/DisableReload:
   Enabled: pending
   VersionAdded: '0.93'
 
+Performance/RequireFileOpenBlock:
+  Description: 'Enforce opening files with a block to ensure the file gets closed.'
+  Enabled: pending
+  VersionAdded: '1.31.2'
+
 Style/DisableProgrammaticEnumValue:
   Description: 'Disallow users to create enums with an each_value statement'
   Enabled: pending

--- a/lib/rubocop/cop/notarize_cops.rb
+++ b/lib/rubocop/cop/notarize_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 require_relative 'performance/disable_reload'
+require_relative 'performance/require_file_open_block'
 require_relative 'style/disable_programmatic_enum_value'

--- a/lib/rubocop/cop/performance/require_file_open_block.rb
+++ b/lib/rubocop/cop/performance/require_file_open_block.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Performance
+      # Enforce passing a block to File.open to ensure the file is closed after use.
+      #
+      # @example RequireFileOpenBlock: true (default)
+      #
+      #   # bad
+      #   file = File.open(file_path)
+      #   body = file.read
+      #   file.close
+      #
+      #   # good
+      #   body = File.open(file_path) { |file| file.read }
+      #
+      class RequireFileOpenBlock < Base
+        MSG = 'Use File.open with a block to ensure the file is closed after use.'.freeze
+
+        def_node_matcher :open_call?, <<~PATTERN
+          (send (...) :open ...)
+        PATTERN
+
+        def on_send(node)
+          add_offense(node) if open_call?(node) && !node.parent.is_a?(RuboCop::AST::BlockNode)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/notarize/version.rb
+++ b/lib/rubocop/notarize/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Notarize
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end

--- a/rubocop-notarize.gemspec
+++ b/rubocop-notarize.gemspec
@@ -3,7 +3,7 @@ require_relative 'lib/rubocop/notarize/version'
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-notarize"
   spec.version       = RuboCop::Notarize::VERSION
-  spec.authors       = ['Arturo Gonzalez', 'Matt Murphey', 'Jeremie Charrier']
+  spec.authors       = ['Arturo Gonzalez', 'Matthew Murphy', 'Jérémie Charrier']
 
   spec.summary       = 'Create Linting rules for Notarize platform'
   spec.description   = 'Custom linting rules for notarize Rupy platform'

--- a/spec/rubocop/cop/performance/require_file_open_block_spec.rb
+++ b/spec/rubocop/cop/performance/require_file_open_block_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Performance::RequireFileOpenBlock do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using .open with a String parameter' do
+    expect_offense(<<~RUBY)
+      File.open("file_path")
+      ^^^^^^^^^^^^^^^^^^^^^^ Use File.open with a block to ensure the file is closed after use.
+    RUBY
+  end
+
+  it 'registers an offense when using .open with a parameter' do
+    expect_offense(<<~RUBY)
+      File.open(file_path)
+      ^^^^^^^^^^^^^^^^^^^^ Use File.open with a block to ensure the file is closed after use.
+    RUBY
+  end
+
+  it 'registers an offense when using .open with 2 parameters' do
+    expect_offense(<<~RUBY)
+      f = File.open("file_path", 'w')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use File.open with a block to ensure the file is closed after use.
+    RUBY
+  end
+
+  it 'registers an offense when assigning .open to a variable' do
+    expect_offense(<<~RUBY)
+      file = File.open(file_path)
+             ^^^^^^^^^^^^^^^^^^^^ Use File.open with a block to ensure the file is closed after use.
+    RUBY
+  end
+
+  it 'registers an offense when using .open with .tap' do
+    expect_offense(<<~RUBY)
+      File.open(file_path).tap do |file|
+      ^^^^^^^^^^^^^^^^^^^^ Use File.open with a block to ensure the file is closed after use.
+        file.read
+      end
+    RUBY
+  end
+
+  it 'registers an offense when yielding .open without a block' do
+    expect_offense(<<~RUBY)
+      yield(@image.tempfile.open).tap { @image.tempfile.close }
+            ^^^^^^^^^^^^^^^^^^^^ Use File.open with a block to ensure the file is closed after use.
+    RUBY
+  end
+
+  it 'registers an offense when using .open in an inline condition' do
+    expect_offense(<<~RUBY)
+      tempfile.open if tempfile.closed? && !opts[:unlink]
+      ^^^^^^^^^^^^^ Use File.open with a block to ensure the file is closed after use.
+    RUBY
+  end
+
+  it 'registers an offense when using .open in an hash' do
+    expect_offense(<<~RUBY)
+      remote_png_asset = RemoteFileStorage.assets.upload_file(
+        file: png.tempfile.open,
+              ^^^^^^^^^^^^^^^^^ Use File.open with a block to ensure the file is closed after use.
+        key: png_key,
+        options: { content_type: png.mime_type }
+      )
+    RUBY
+  end
+
+  it 'registers an offense when chaining .open with another call' do
+    expect_offense(<<~RUBY)
+      Base64.strict_encode64(image.tempfile.open.read)
+                             ^^^^^^^^^^^^^^^^^^^ Use File.open with a block to ensure the file is closed after use.
+    RUBY
+  end
+
+  it 'does not register an offense when using .open with an inline block' do
+    expect_no_offenses(<<~RUBY)
+      File.open(file_path) { |file| file.read }
+    RUBY
+  end
+
+  it 'does not register an offense when assigning .open with an inline block' do
+    expect_no_offenses(<<~RUBY)
+      xml_file = remote_file.open { |contents| Nokogiri::XML(contents) }
+    RUBY
+  end
+
+  it 'does not register an offense when using .open with a multiline block' do
+    expect_no_offenses(<<~RUBY)
+      File.open("jeremie") do |file|
+        file.read
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using .open with 2 parameters and an inline block' do
+    expect_no_offenses(<<~RUBY)
+      File.open(@image.path, 'rb') do |file|
+        Base64.strict_encode64(file.read)
+      end
+    RUBY
+  end
+end
+


### PR DESCRIPTION
Create a Cop to enforce `File.open` with a block which will make sure the file is closed after being used.