### PR TITLE
Add GraphCamelize Cop to prevent usage of camelize

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-notarize (0.1.4)
+    rubocop-notarize (0.1.5)
       rubocop (>= 0.92)
 
 GEM

--- a/Rakefile
+++ b/Rakefile
@@ -20,11 +20,7 @@ task :new_cop, [:cop] do |_task, args|
     exit!
   end
 
-  github_user = `git config github.user`.chop
-  github_user = 'your_id' if github_user.empty?
-
-  generator = RuboCop::Cop::Generator.new(cop_name, github_user)
-
+  generator = RuboCop::Cop::Generator.new(cop_name)
   generator.write_source
   generator.write_spec
   generator.inject_require(root_file_path: 'lib/rubocop/cop/notarize_cops.rb')

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,19 +1,19 @@
 Performance/DisableReload:
   Description: 'Disallow users to call .reload on an ActiveRecord object'
-  Enabled: pending
-  VersionAdded: '0.93'
+  Enabled: true
+  VersionAdded: '0.1.5'
 
 Performance/RequireFileOpenBlock:
   Description: 'Enforce opening files with a block to ensure the file gets closed.'
-  Enabled: pending
-  VersionAdded: '1.31.2'
+  Enabled: true
+  VersionAdded: '0.1.5'
 
 Style/DisableProgrammaticEnumValue:
   Description: 'Disallow users to create enums with an each_value statement'
-  Enabled: pending
-  VersionAdded: '0.93'
+  Enabled: true
+  VersionAdded: '0.1.5'
 
 Style/GraphCamelize:
-  Description: 'TODO: Write a description of the cop.'
-  Enabled: pending
-  VersionAdded: '<<next>>'
+  Description: 'Do not use the GraphQL camelize option as we always want the default value (true).'
+  Enabled: true
+  VersionAdded: '0.1.5'

--- a/config/default.yml
+++ b/config/default.yml
@@ -12,3 +12,8 @@ Style/DisableProgrammaticEnumValue:
   Description: 'Disallow users to create enums with an each_value statement'
   Enabled: pending
   VersionAdded: '0.93'
+
+Style/GraphCamelize:
+  Description: 'TODO: Write a description of the cop.'
+  Enabled: pending
+  VersionAdded: '<<next>>'

--- a/lib/rubocop/cop/notarize_cops.rb
+++ b/lib/rubocop/cop/notarize_cops.rb
@@ -3,3 +3,4 @@
 require_relative 'performance/disable_reload'
 require_relative 'performance/require_file_open_block'
 require_relative 'style/disable_programmatic_enum_value'
+require_relative 'style/graph_camelize'

--- a/lib/rubocop/cop/style/graph_camelize.rb
+++ b/lib/rubocop/cop/style/graph_camelize.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      # Do not use the GraphQL camelize option as we always want the default value (true).
+      #
+      # @example GraphCamelize: true (default)
+      #
+      #   # bad
+      #   field :updated_at, String, null: true, camelize: false
+      #
+      #   # good
+      #   field :updated_at, String, null: true
+      #
+      class GraphCamelize < Base
+        extend AutoCorrector
+
+        MSG = 'Do not use the camelize option.'
+        RESTRICT_ON_SEND = %i[argument field].freeze
+        INCORRECT_OPTION = 'camelize'
+
+        def on_send(node)
+          node.children.each do |argument|
+            next unless argument.respond_to?(:type) && argument.type == :hash
+
+            argument.children.each do |pair|
+              next unless pair.key.value.to_s == INCORRECT_OPTION
+
+              add_offense(pair) do |corrector|
+                corrector.remove(get_range_to_remove(pair))
+              end
+            end
+          end
+        end
+
+        private
+
+        def get_range_to_remove(node)
+          left_node = node.left_sibling || node.parent&.left_sibling
+          begin_pos = left_node&.source_range&.end_pos || node.source_range.begin_pos
+          end_pos = node.source_range.end_pos
+          Parser::Source::Range.new(node.source_range.source_buffer, begin_pos, end_pos)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/notarize/version.rb
+++ b/lib/rubocop/notarize/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Notarize
-    VERSION = '0.1.4'
+    VERSION = '0.1.5'
   end
 end

--- a/spec/rubocop/cop/style/graph_camelize_spec.rb
+++ b/spec/rubocop/cop/style/graph_camelize_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Style::GraphCamelize, :config do
+  it 'registers offenses when using camelize in arguments definitions' do
+    expect_offense(<<~RUBY)
+      argument :first_name, String, camelize: false, required: true
+                                    ^^^^^^^^^^^^^^^ Do not use the camelize option.
+      argument :first_name, String, required: true, camelize: true
+                                                    ^^^^^^^^^^^^^^ Do not use the camelize option.
+      argument :name,
+               required: true,
+               camelize: false,
+               ^^^^^^^^^^^^^^^ Do not use the camelize option.
+               description: "a name"
+      argument :name,
+               required: true,
+               description: "a name",
+               camelize: true
+               ^^^^^^^^^^^^^^ Do not use the camelize option.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      argument :first_name, String, required: true
+      argument :first_name, String, required: true
+      argument :name,
+               required: true,
+               description: "a name"
+      argument :name,
+               required: true,
+               description: "a name"
+    RUBY
+  end
+
+  it 'registers offenses when using camelize in fields definitions' do
+    expect_offense(<<~RUBY)
+      field :updated_at, String, null: true, camelize: false
+                                             ^^^^^^^^^^^^^^^ Do not use the camelize option.
+      field :updated_at, String, camelize: true, null: true
+                                 ^^^^^^^^^^^^^^ Do not use the camelize option.
+      field :updated_at, String,
+            null: true,
+            camelize: false
+            ^^^^^^^^^^^^^^^ Do not use the camelize option.
+      field :updated_at, String,
+            camelize: true,
+            ^^^^^^^^^^^^^^ Do not use the camelize option.
+            null: true
+    RUBY
+
+    expect_correction(<<~RUBY)
+      field :updated_at, String, null: true
+      field :updated_at, String, null: true
+      field :updated_at, String,
+            null: true
+      field :updated_at, String,
+            null: true
+    RUBY
+  end
+
+  it 'registers offenses when using camelize in a complex field definition' do
+    expect_offense(<<~RUBY) \
+      field :queried_users, Graph::Connections::UserConnection, null: false, camelize: false, extras: [:lookahead] do
+                                                                             ^^^^^^^^^^^^^^^ Do not use the camelize option.
+        description "Find users by some attributes, admin users only"
+
+        argument :query, String, camelize: false, description: 'Meeting / transaction gid, user email, last name or gid / id', required: false
+                                 ^^^^^^^^^^^^^^^ Do not use the camelize option.
+        argument :include_single_use, Boolean, description: '', required: false, default_value: false
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      field :queried_users, Graph::Connections::UserConnection, null: false, extras: [:lookahead] do
+        description "Find users by some attributes, admin users only"
+
+        argument :query, String, description: 'Meeting / transaction gid, user email, last name or gid / id', required: false
+        argument :include_single_use, Boolean, description: '', required: false, default_value: false
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
### Purpose
Add a Cop to prevent usage of the `camelize` keyword in our Graph definitions, because we always want the default value (true).

### Testing
- [x] passes rspec
- [x] passes linter