### PR TITLE
Add a new Rubocop that requires frozen_string_literal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-notarize (0.1.7)
+    rubocop-notarize (0.1.8)
       rubocop (>= 0.92)
 
 GEM

--- a/config/default.yml
+++ b/config/default.yml
@@ -27,3 +27,8 @@ Style/GraphCamelize:
   Description: 'Do not use the GraphQL camelize option as we always want the default value (true).'
   Enabled: true
   VersionAdded: '0.1.5'
+
+Performance/RequireFrozenStringLiteral:
+  Description: 'Require # frozen_string_literal: true in any file that creates a string literal'
+  Enabled: false
+  VersionAdded: '0.1.8'

--- a/lib/rubocop/cop/notarize_cops.rb
+++ b/lib/rubocop/cop/notarize_cops.rb
@@ -2,6 +2,7 @@
 
 require_relative 'performance/disable_reload'
 require_relative 'performance/require_file_open_block'
+require_relative 'performance/require_frozen_string_literal'
 require_relative 'style/disable_programmatic_enum_value'
 require_relative 'style/graph_camelize'
 require_relative 'sidekiq/require_sidekiq_testing_inline_block'

--- a/lib/rubocop/cop/performance/require_frozen_string_literal.rb
+++ b/lib/rubocop/cop/performance/require_frozen_string_literal.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'pry'
+
+module RuboCop
+  module Cop
+    module Performance
+      # Enforce marking a file as # frozen_string_literal: true if the file creates any string literals
+      #
+      # @example RequireFrozenStringLiteral: true (default)
+      #
+      #   # bad
+      #   my_string = "hello"
+      #
+      #   # good
+      #   # frozen_string_literal: true
+      #   my_string = "hello"
+      #
+      class RequireFrozenStringLiteral < Base
+        include RangeHelp
+        include FrozenStringLiteral
+
+        MSG = 'Require "# frozen_string_literal: true" in any file that creates a string literal'
+
+        def on_new_investigation
+          return if processed_source.tokens.empty?
+          return unless !frozen_string_literal_comment_exists? && contains_string_literal?
+
+          add_offense(source_range(processed_source.buffer, 0, 0), message: MSG)
+        end
+
+        private
+
+        def contains_string_literal?
+          processed_source.tokens.any? { |token| token.type == :tSTRING }
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/notarize/version.rb
+++ b/lib/rubocop/notarize/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Notarize
-    VERSION = '0.1.7'
+    VERSION = '0.1.8'
   end
 end

--- a/spec/rubocop/cop/performance/require_frozen_string_literal_spec.rb
+++ b/spec/rubocop/cop/performance/require_frozen_string_literal_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Performance::RequireFrozenStringLiteral, :config do
+  it 'has the comment' do
+    expect_no_offenses(<<~RUBY)
+      # typed: strict
+      # frozen_string_literal: true
+      module Thing; end
+    RUBY
+  end
+
+  it 'has the comment and a string constant' do
+    expect_no_offenses(<<~RUBY)
+      # typed: strict
+      # frozen_string_literal: true
+      module Thing
+        STRING_CONSTANT = "hello there"
+      end
+    RUBY
+  end
+
+  it 'has the comment and a string present inside a class method' do
+    expect_no_offenses(<<~RUBY)
+      # typed: strict
+      # frozen_string_literal: true
+      module Thing
+        def self.create_string
+          my_string = "this is a string"
+        end
+      end
+    RUBY
+  end
+
+  it 'has the comment and a string present inside an instance method' do
+    expect_no_offenses(<<~RUBY)
+      # typed: strict
+      # frozen_string_literal: true
+      module Thing
+        def create_string
+          my_string = "this is a string"
+        end
+      end
+    RUBY
+  end
+
+  it 'does not have the comment and a string constant' do
+    expect_offense(<<~RUBY)
+      # typed: strict
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+      module Thing
+        STRING_CONSTANT = "hello there"
+      end
+    RUBY
+  end
+
+  it 'does not have the comment and a string present inside a class method' do
+    expect_offense(<<~RUBY)
+      # typed: strict
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+      module Thing
+        def self.create_string
+          my_string = "this is a string"
+        end
+      end
+    RUBY
+  end
+
+  it 'does not have the comment and a string present inside an instance method' do
+    expect_offense(<<~RUBY)
+      # typed: strict
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+      module Thing
+        def create_string
+          my_string = "this is a string"
+        end
+      end
+    RUBY
+  end
+
+  it 'does not have the comment but has a string present, even if frozen' do
+    expect_offense(<<~RUBY)
+      # typed: strict
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+      module Thing
+        STRING_CONSTANT1 = "hello there".freeze
+      end
+    RUBY
+  end
+
+  it 'does not have the comment but has a string present' do
+    expect_offense(<<~RUBY)
+      # typed: strict
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+      module Thing
+        STRING_CONSTANT2 = 'hello there'
+      end
+    RUBY
+  end
+
+  it 'does not have the comment but has a string that is concatenated' do
+    expect_offense(<<~RUBY)
+      # typed: strict
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+      module Thing
+        STRING_CONSTANT3 = "h" + "ello there"
+      end
+    RUBY
+  end
+
+  it 'does not have the comment but has an interpolated string' do
+    expect_offense(<<~RUBY)
+      # typed: strict
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+      module Thing
+        INTEGER_CONSTANT = 123
+        STRING_CONSTANT4 = "hello #{INTEGER_CONSTANT}"
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
The only existing Rubocop regarding frozen_string_literal is one that simply requires the comment be present in _every_ file. The Ruby 3.4 behavior is described as requiring the frozen_string_literal comment in files that define string literals. Add a new custom cop to replicate that behavior, so we can run it on new files and work on cleaning up existing non-frozen string literals.