### PR TITLE
Support Autocorrect in RequireFrozenStringLiteral

### DIFF
--- a/lib/rubocop/cop/performance/require_frozen_string_literal.rb
+++ b/lib/rubocop/cop/performance/require_frozen_string_literal.rb
@@ -19,6 +19,7 @@ module RuboCop
       class RequireFrozenStringLiteral < Base
         include RangeHelp
         include FrozenStringLiteral
+        extend RuboCop::Cop::AutoCorrector
 
         MSG = 'Require "# frozen_string_literal: true" in any file that creates a string literal'
 
@@ -26,13 +27,39 @@ module RuboCop
           return if processed_source.tokens.empty?
           return unless !frozen_string_literal_comment_exists? && contains_string_literal?
 
-          add_offense(source_range(processed_source.buffer, 0, 0), message: MSG)
+          add_offense(source_range(processed_source.buffer, 0, 0), message: MSG) do |corrector|
+            insert_comment(corrector)
+          end
         end
 
         private
 
         def contains_string_literal?
           processed_source.tokens.any? { |token| token.type == :tSTRING }
+        end
+
+        def insert_comment(corrector)
+          comment = last_special_comment(processed_source)
+
+          if comment
+            corrector.insert_after(processed_source.buffer.line_range(comment.line), "\n#{FROZEN_STRING_LITERAL_ENABLED}")
+          else
+            corrector.insert_before(processed_source.buffer.source_range, "#{FROZEN_STRING_LITERAL_ENABLED}\n")
+          end
+        end
+
+        def last_special_comment(processed_source)
+          token_number = 0
+          token = nil
+          next_token = processed_source.tokens[token_number]
+
+          while MagicComment.parse(next_token.text).any?
+            token_number += 1
+            token = next_token
+            next_token = processed_source.tokens[token_number]
+          end
+
+          token
         end
       end
     end

--- a/lib/rubocop/cop/performance/require_frozen_string_literal.rb
+++ b/lib/rubocop/cop/performance/require_frozen_string_literal.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
-
 module RuboCop
   module Cop
     module Performance
@@ -22,6 +20,7 @@ module RuboCop
         extend RuboCop::Cop::AutoCorrector
 
         MSG = 'Require "# frozen_string_literal: true" in any file that creates a string literal'
+        STRING_TOKEN_TYPES = [:tSTRING, :tSTRING_CONTENT].freeze
 
         def on_new_investigation
           return if processed_source.tokens.empty?
@@ -35,7 +34,7 @@ module RuboCop
         private
 
         def contains_string_literal?
-          processed_source.tokens.any? { |token| token.type == :tSTRING }
+          processed_source.tokens.any? { |token| STRING_TOKEN_TYPES.any?(token.type) }
         end
 
         def insert_comment(corrector)
@@ -53,7 +52,7 @@ module RuboCop
           token = nil
           next_token = processed_source.tokens[token_number]
 
-          while MagicComment.parse(next_token.text).any?
+          while next_token.text.start_with?(Style::Encoding::SHEBANG) || MagicComment.parse(next_token.text).any?
             token_number += 1
             token = next_token
             next_token = processed_source.tokens[token_number]

--- a/lib/rubocop/notarize/version.rb
+++ b/lib/rubocop/notarize/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Notarize
-    VERSION = '0.1.8'
+    VERSION = '0.1.9'
   end
 end

--- a/spec/rubocop/cop/performance/require_frozen_string_literal_spec.rb
+++ b/spec/rubocop/cop/performance/require_frozen_string_literal_spec.rb
@@ -108,12 +108,116 @@ RSpec.describe RuboCop::Cop::Performance::RequireFrozenStringLiteral, :config do
   end
 
   it 'does not have the comment but has an interpolated string' do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~'RUBY')
       # typed: strict
       ^ Require "# frozen_string_literal: true" in any file that creates a string literal
       module Thing
         INTEGER_CONSTANT = 123
         STRING_CONSTANT4 = "hello #{INTEGER_CONSTANT}"
+      end
+    RUBY
+  end
+
+  it 'autocorrects by adding a frozen string literal comment under an encoding comment' do
+    expect_offense(<<~RUBY)
+      # encoding: utf-8
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+      VAL = "hello"
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # encoding: utf-8
+      # frozen_string_literal: true
+      VAL = "hello"
+    RUBY
+  end
+
+  it 'autocorrects by adding a frozen string literal comment under a Sorbet comment' do
+    expect_offense(<<~RUBY)
+      # typed: true
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+
+      VAL = "hello"
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # typed: true
+      # frozen_string_literal: true
+
+      VAL = "hello"
+    RUBY
+  end
+
+  it 'autocorrects by adding a frozen string literal comment under a shebang comment' do
+    expect_offense(<<~RUBY)
+      #!/usr/bin/env ruby
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+
+      VAL = "hello"
+    RUBY
+
+    expect_correction(<<~RUBY)
+      #!/usr/bin/env ruby
+      # frozen_string_literal: true
+
+      VAL = "hello"
+    RUBY
+  end
+
+  it 'autocorrects by adding a frozen string literal comment before non-magic leading comment lines' do
+    expect_offense(<<~RUBY)
+      #!/usr/bin/env ruby
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+      # typed: strict
+      # encoding: utf-8
+      # hey how's it going? 
+
+      VAL = "hello"
+    RUBY
+
+    expect_correction(<<~RUBY)
+      #!/usr/bin/env ruby
+      # typed: strict
+      # encoding: utf-8
+      # frozen_string_literal: true
+      # hey how's it going? 
+
+      VAL = "hello"
+    RUBY
+  end
+
+  it 'autocorrects by adding a frozen string literal comment if there are no leading magic comment lines' do
+    expect_offense(<<~RUBY)
+      module Module1
+      ^ Require "# frozen_string_literal: true" in any file that creates a string literal
+        VAL = "hello"
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # frozen_string_literal: true
+      module Module1
+        VAL = "hello"
+      end
+    RUBY
+  end
+
+  it 'autocorrects by adding a frozen string literal comment if there are no leading magic comment lines but there are leading empty lines' do
+    expect_offense(<<~RUBY)
+
+      ^{} Require "# frozen_string_literal: true" in any file that creates a string literal
+
+      module Module1
+        VAL = "hello"
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # frozen_string_literal: true
+
+
+      module Module1
+        VAL = "hello"
       end
     RUBY
   end


### PR DESCRIPTION
Add support for passing --autocorrect to rubocop for the custom RequireFrozenStringLiteral cop. This will allow us to automatically add the magic comment in bulk for directory paths to help with the rollout for the entire repository.